### PR TITLE
feat: add helper to get request object

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,45 +24,30 @@ const { user_id } = await auth.getPayload() // returns access token payload data
 
 #### Send signed request
 
-With the `accessToken` and the `userKey` you should be able to send a signed request to the service provider you are trying to reach.
-
 ```ts
-const AuthModule = require('decentraland-auth-protocol')
-const Buffer = require('buffer/').Buffer //To use buffer from the browser
+const auth = new Auth()
+await auth.login()
 
-let accessToken = await auth.getToken()
-const userKey = auth.getUserKey()
-const fullURL = 'https://theService.com/path/param/?query=something'
-
-// GET request example
-const input = AuthModule.MessageInput.fromHttpRequest('GET', fullURL, null)
-
-let requestMandatoryHeaders = userKey.makeMessageCredentials(input, accessToken)
-
-const response = await fetch(fullURL, {
-  method: 'get',
-  headers: requestMandatoryHeaders
-})
-
-// POST request example
-accessToken = await auth.getToken()
-const body = Buffer.from(
-  JSON.stringify({ param1: 'data1', param2: 'data2' }),
-  'utf8'
+// GET
+const request = await auth.getRequest(
+  'some-service.decentraland.org/path?query=param'
 )
+const response = await fetch(request)
 
-const inputPost = AuthModule.MessageInput.fromHttpRequest('POST', fullURL, body)
-
-requestMandatoryHeaders = userKey.makeMessageCredentials(inputPost, accessToken)
-
-let response = await fetch(fullURL, {
-  method: 'post',
-  headers: requestMandatoryHeaders,
-  body
-})
+// POST
+const request = await auth.getRequest(
+  'some-service.decentraland.org/do-something',
+  {
+    method: 'post',
+    headers: {
+      'Some-Header': 'bla bla'
+    },
+    body: JSON.stringify({ param: 'asdf' })
+  }
+)
 ```
 
-- [Buffer Library](https://github.com/feross/buffer)
+This library makes use of `Buffer`, which is not present natively in the browser. There's a polyfill that is included by default by some bundlers (like webpack), but if you don't have it make sure to add it to your project: [Buffer](https://github.com/feross/buffer).
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ const request = await auth.getRequest(
     body: JSON.stringify({ param: 'asdf' })
   }
 )
+const response = await fetch(request)
 ```
 
 This library makes use of `Buffer`, which is not present natively in the browser. There's a polyfill that is included by default by some bundlers (like webpack), but if you don't have it make sure to add it to your project: [Buffer](https://github.com/feross/buffer).

--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ This library makes use of `Buffer`, which is not present natively in the browser
 
 - `auth.login([target])`: Returns a promise that will resolve once the user is logged in. The first time it's called it will prompt the user to login though a Popup. If a `target` dom node is provided, instead of a Popup it will insert an iframe inside the target node and use that. If the user closes the Popup the promise will reject. If the user session is still active this method might resolve without having to open a popup.
 
-- `auth.getToken()`: It returns an access token. This access token has a short life so it is recommended to get a new token every time you need to use is instead of storing it.
+- `auth.getToken()`: It returns a promise that resolves to an access token. This access token has a short life so it is recommended to get a new token every time you need to use is instead of storing it.
 
-- `auth.getPayload()`: It returns the payload of the access token (basically the decoded JWT).
+- `auth.getPayload()`: It returns a promise that resolves to the payload of the access token (basically the decoded JWT).
 
 - `auth.logout()`: It returns a promise that resolves once the user is logged out. After using this, the next time the `login()` method is called it will prompt the user with the login flow.
 
@@ -79,6 +79,10 @@ This library makes use of `Buffer`, which is not present natively in the browser
 
 - `auth.getUserToken()`: It returns a promise that resolves to the `userToken`. This token is the one used to generate the `accessToken`(s).
 
+- `auth.getRequest(url, options?)`: It returns a promise that resolves to a `Request` object that can be used with `fetch`. It takes a URL and the same options as `fetch`.
+
+- `auth.getHeaders(url, options?)`: It returns a promise that resolves to an object containing the mandatory headers to be used in a signed request. It takes a URL and the same options as `fetch`.
+
 - `auth.getUserKey()`: Returns the instance of the ephemeral key.
 
-- `auth.dispose()`: It removes all the bindings and on this instance. It does NOT perform a logout.
+- `auth.dispose()`: It removes all the bindings on this instance. It does NOT perform a logout.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1394,9 +1394,9 @@
       }
     },
     "decentraland-auth-protocol": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/decentraland-auth-protocol/-/decentraland-auth-protocol-0.2.0.tgz",
-      "integrity": "sha512-+qrDE23g+rG3IiwQdbuj5t0U0XMCFvwFmROvCtslQGV0KtkPzJ48uSp9s3Kc1a7y8QIfckCXqJon1x7DN3B9uQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/decentraland-auth-protocol/-/decentraland-auth-protocol-0.3.0.tgz",
+      "integrity": "sha512-BEH/QAUDgENxbybnRKuETmZvkIT2THrQGLgSI+qsHEe1cyKiMg+KwYviBVQXwnyHNfSSeRmlgiCLpt7oRk29ZA==",
       "requires": {
         "@types/secp256k1": "^3.5.0",
         "jsonwebtoken": "^8.5.0",
@@ -4079,7 +4079,9 @@
     "nan": {
       "version": "2.13.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
-      "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw=="
+      "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
+      "dev": true,
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -4939,9 +4941,9 @@
       }
     },
     "secp256k1": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.7.0.tgz",
-      "integrity": "sha512-YlUIghD6ilkMkzmFJpIdVjiamv2S8lNZ9YMwm1XII9JC0NcR5qQiv2DOp/G37sExBtaMStzba4VDJtvBXEbmMQ==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.7.1.tgz",
+      "integrity": "sha512-1cf8sbnRreXrQFdH6qsg2H71Xw91fCCS9Yp021GnUNJzWJS/py96fS4lHbnTnouLp08Xj6jBoBB6V78Tdbdu5g==",
       "requires": {
         "bindings": "^1.5.0",
         "bip66": "^1.1.5",
@@ -4949,8 +4951,15 @@
         "create-hash": "^1.2.0",
         "drbg.js": "^1.0.1",
         "elliptic": "^6.4.1",
-        "nan": "^2.13.2",
+        "nan": "^2.14.0",
         "safe-buffer": "^5.1.2"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.14.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+        }
       }
     },
     "select-hose": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "ISC",
   "dependencies": {
     "@types/jsonwebtoken": "^8.3.2",
-    "decentraland-auth-protocol": "^0.2.1",
+    "decentraland-auth-protocol": "^0.3.0",
     "fp-future": "^1.0.1",
     "jsonwebtoken": "^8.5.1",
     "typescript": "^3.3.4000"

--- a/src/Auth.ts
+++ b/src/Auth.ts
@@ -122,11 +122,11 @@ export class Auth {
     }
 
     let method = 'GET'
-    let body: Buffer | null = null
+    let body: any = null
     let headers: Record<string, string> = {}
 
     if (options.method) {
-      method = options.method.toLowerCase()
+      method = options.method.toUpperCase()
     }
 
     if (options.body) {
@@ -141,8 +141,9 @@ export class Auth {
       input,
       accessToken
     )
-
-    requiredHeaders.forEach((key, value) => (headers[key] = value))
+    for (const [key, value] of requiredHeaders.entries()) {
+      headers[key] = value
+    }
 
     // add optional headers
     if (options && options.headers) {

--- a/src/Auth.ts
+++ b/src/Auth.ts
@@ -1,5 +1,5 @@
 import * as jwt from 'jsonwebtoken'
-import { SimpleCredential, MessageInput } from 'decentraland-auth-protocol'
+import { BasicEphemeralKey, MessageInput } from 'decentraland-auth-protocol'
 
 import { Login } from './Login'
 import { API, APIOptions } from './API'
@@ -26,7 +26,7 @@ export class Auth {
   private accessToken: string | null = null
   private renewalTimeout: number | null = null
   private serverPublicKey: string | null = null
-  private ephemeralKey: SimpleCredential | null = null
+  private ephemeralKey: BasicEphemeralKey | null = null
   private loginManager: Login
 
   constructor(options: Partial<AuthOptions> = {}) {
@@ -177,7 +177,7 @@ export class Auth {
 
   private getPublicKey() {
     if (!this.ephemeralKey || this.ephemeralKey.hasExpired()) {
-      this.ephemeralKey = SimpleCredential.generateNewKey(
+      this.ephemeralKey = BasicEphemeralKey.generateNewKey(
         this.options.ephemeralKeyTTL
       )
     }

--- a/src/Auth.ts
+++ b/src/Auth.ts
@@ -116,7 +116,7 @@ export class Auth {
     return accessToken
   }
 
-  async getHeaders(url: string, options?: RequestInit) {
+  async getHeaders(url: string, options: RequestInit = {}) {
     if (!this.isLoggedIn()) {
       await this.login()
     }
@@ -125,13 +125,12 @@ export class Auth {
     let body: Buffer | null = null
     let headers: Record<string, string> = {}
 
-    if (options) {
-      if (options.method) {
-        method = options.method.toLowerCase()
-      }
-      if (options.body) {
-        body = Buffer.from(options.body as string)
-      }
+    if (options.method) {
+      method = options.method.toLowerCase()
+    }
+
+    if (options.body) {
+      body = Buffer.from(options.body as string)
     }
 
     const input = MessageInput.fromHttpRequest(method, url, body)
@@ -157,9 +156,9 @@ export class Auth {
     return headers
   }
 
-  async getRequest(url: string, options?: RequestInit) {
+  async getRequest(url: string, options: RequestInit = {}) {
     let headers = await this.getHeaders(url, options)
-    if (options && options.headers) {
+    if (options.headers) {
       headers = { ...(options.headers as Record<string, string>), ...headers }
     }
 


### PR DESCRIPTION
#### Send signed request

```ts
const auth = new Auth()
await auth.login()

// GET
const request = await auth.getRequest('some-service.decentraland.org/path?query=param')
const response = await fetch(request)

// POST
const request = await auth.getRequest('some-service.decentraland.org/do-something', {
  method: 'post',
  headers: {
    'Some-Header': 'bla bla'
  },
  body: JSON.stringify({ param: 'asdf' })
})
const response = await fetch(request)
```